### PR TITLE
feat(scanner): support memoized values

### DIFF
--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -409,7 +409,7 @@ def test_scan_directory_path():
             Global("collections", "OrderedDict", SafetyLevel.Innocuous),
             Global("torch._utils", "_rebuild_tensor_v2", SafetyLevel.Innocuous),
             Global("torch", "FloatStorage", SafetyLevel.Innocuous),
-            Global("unknown", "unknown", SafetyLevel.Dangerous),
+            Global("_rebuild_tensor", "unknown", SafetyLevel.Dangerous),
             Global("torch._utils", "_rebuild_tensor", SafetyLevel.Suspicious),
             Global("torch", "_utils", SafetyLevel.Suspicious),
         ],


### PR DESCRIPTION
A lot of imports are marked as `unknown` when they could simply be fetched from the memo.

This PR also contains a small fix where `unknown` could be present in an import and not be marked as dangerous.

cc @BenjaminBossan