### PR TITLE
fix: handle broken pickled files better

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pytest-cov==3.0.0
 requests==2.31.0
 aiohttp==3.9.1
 black==22.8.0
-numpy==1.24.0
+numpy>1.24.0

--- a/tests/data/broken_model.pkl
+++ b/tests/data/broken_model.pkl
@@ -1,0 +1,4 @@
+cbuiltins
+exec
+(X>
+f = open('my_file.txt', 'a'); f.write('Malicious'); f.close()tRX.

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -323,6 +323,12 @@ def initialize_pickle_files():
         ),
     )
 
+    # Broken model
+    initialize_data_file(
+        f"{_root_path}/data/broken_model.pkl",
+        b"cbuiltins\nexec\n(X>\nf = open('my_file.txt', 'a'); f.write('Malicious'); f.close()tRX.",
+    )
+
     # Code which created malicious12.pkl using pickleassem (see https://github.com/gousaiyang/pickleassem)
     #
     # p = PickleAssembler(proto=4)
@@ -629,7 +635,6 @@ def test_scan_file_path():
 
 
 def test_scan_file_path_npz():
-
     compare_scan_results(
         scan_file_path(f"{_root_path}/data2/object_arrays.npz"),
         ScanResult(
@@ -726,10 +731,11 @@ def test_scan_directory_path():
             Global("bdb", "Bdb", SafetyLevel.Dangerous),
             Global("bdb", "Bdb", SafetyLevel.Dangerous),
             Global("bdb", "Bdb.run", SafetyLevel.Dangerous),
+            Global("builtins", "exec", SafetyLevel.Dangerous),
         ],
-        scanned_files=30,
-        issues_count=30,
-        infected_files=25,
+        scanned_files=31,
+        issues_count=31,
+        infected_files=26,
         scan_err=True,
     )
     compare_scan_results(scan_directory_path(f"{_root_path}/data/"), sr)


### PR DESCRIPTION
A user reported that broken pickle files can still be partially deserialized and cause damage.

Small fix to better catch imports in such cases, we try to deserialize the pickle as far as we can before exiting the main loop.

cf https://huggingface.co/kzanki/broken_model/tree/main