### PR TITLE
Detect mailcap.findmatch pickle payloads

### DIFF
--- a/src/picklescan/scanner.py
+++ b/src/picklescan/scanner.py
@@ -192,6 +192,7 @@ _unsafe_globals = {
     "imaplib": {"IMAP4_stream"},  # IMAP4_stream executes commands via subprocess.Popen(command, shell=True)
     "lib2to3.pgen2.grammar": {"Grammar.loads"},
     "lib2to3.pgen2.pgen": {"ParserGenerator.make_label"},
+    "mailcap": {"findmatch"},  # mailcap.findmatch executes matching entry test commands via os.system()
     "pdb": "*",
     "pickle": "*",
     "_pickle": "*",

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -42,6 +42,14 @@ class Malicious2:
         return os.system, ("ls -la",)
 
 
+class MaliciousMailcapFindmatch:
+    def __reduce__(self):
+        import mailcap
+
+        caps = {"text/plain": [{"view": "cat %s", "test": "true"}]}
+        return mailcap.findmatch, (caps, "text/plain")
+
+
 class HTTPResponse:
     def __init__(self, status, data=None):
         self.status = status
@@ -139,6 +147,12 @@ def test_list_globals():
 def test_scan_pickle_bytes():
     assert scan_pickle_bytes(io.BytesIO(pickle.dumps(Malicious1())), "file.pkl") == ScanResult(
         [Global("builtins", "eval", SafetyLevel.Dangerous)], 1, 1, 1
+    )
+
+
+def test_scan_pickle_bytes_flags_mailcap_findmatch():
+    assert scan_pickle_bytes(io.BytesIO(pickle.dumps(MaliciousMailcapFindmatch())), "mailcap.pkl") == ScanResult(
+        [Global("mailcap", "findmatch", SafetyLevel.Dangerous)], 1, 1, 1
     )
 
 


### PR DESCRIPTION
## Summary
- classify `mailcap.findmatch` as a dangerous pickle global
- add regression coverage for a pickle payload that references `mailcap.findmatch`

## Why
`mailcap.findmatch` can execute a matching mailcap entry `test` command via `os.system()`. Treating it as suspicious only leaves CLI scans with zero dangerous globals and exit code 0.

## Testing
- `uv run --with-editable . --with pytest --with numpy --with py7zr pytest tests/test_scanner.py::test_scan_pickle_bytes_flags_mailcap_findmatch tests/test_scanner.py::test_scan_pickle_bytes`